### PR TITLE
Fix dataset file handle leak

### DIFF
--- a/datasets/dataset_synapse.py
+++ b/datasets/dataset_synapse.py
@@ -65,8 +65,8 @@ class Synapse_dataset(Dataset):
         else:
             vol_name = self.sample_list[idx].strip('\n')
             filepath = self.data_dir + "/{}.npy.h5".format(vol_name)
-            data = h5py.File(filepath)
-            image, label = data['image'][:], data['label'][:]
+            with h5py.File(filepath, 'r') as data:
+                image, label = data['image'][:], data['label'][:]
 
         sample = {'image': image, 'label': label}
         if self.transform:

--- a/test.py
+++ b/test.py
@@ -118,7 +118,13 @@ if __name__ == "__main__":
     net = ViT_seg(config_vit, img_size=args.img_size, num_classes=config_vit.n_classes).cuda()
 
     snapshot = os.path.join(snapshot_path, 'best_model.pth')
-    if not os.path.exists(snapshot): snapshot = snapshot.replace('best_model', 'epoch_'+str(args.max_epochs-1))
+    if not os.path.exists(snapshot):
+        checkpoints = [f for f in os.listdir(snapshot_path) if f.startswith('epoch_') and f.endswith('.pth')]
+        if checkpoints:
+            checkpoints.sort(key=lambda x: int(x.split('_')[1].split('.')[0]))
+            snapshot = os.path.join(snapshot_path, checkpoints[-1])
+        else:
+            snapshot = snapshot.replace('best_model', 'epoch_'+str(args.max_epochs-1))
     net.load_state_dict(torch.load(snapshot))
     snapshot_name = snapshot_path.split('/')[-1]
 

--- a/trainer.py
+++ b/trainer.py
@@ -79,8 +79,8 @@ def trainer_synapse(args, model, snapshot_path):
                 labs = label_batch[1, ...].unsqueeze(0) * 50
                 writer.add_image('train/GroundTruth', labs, iter_num)
 
-        save_interval = 50  # int(max_epoch/6)
-        if epoch_num > int(max_epoch / 2) and (epoch_num + 1) % save_interval == 0:
+        save_interval = 5
+        if (epoch_num + 1) % save_interval == 0:
             save_mode_path = os.path.join(snapshot_path, 'epoch_' + str(epoch_num) + '.pth')
             torch.save(model.state_dict(), save_mode_path)
             logging.info("save model to {}".format(save_mode_path))


### PR DESCRIPTION
## Summary
- close HDF5 files properly when reading validation volumes
- save a model checkpoint every 5 epochs and pick the most recent checkpoint in test

## Testing
- `python -m py_compile trainer.py test.py datasets/dataset_synapse.py`


------
https://chatgpt.com/codex/tasks/task_e_684444fb57c083328a10a5c594100cb1